### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -29,7 +29,7 @@ goog.require('goog.math.Size');
  * @param {number} ry The Y-radius of the ellipse.
  * @param {number} fromAngle The starting angle of the arc (in degrees).
  * @param {number} extent The angular length of the arc (in degrees).
- * @param {boolean=} opt_addFirstPointToResult Defines whether the intial point is added to the result. It is “false”
+ * @param {boolean=} opt_addFirstPointToResult Defines whether the initial point is added to the result. It is “false”
  *    by default, and if it is set to “true”, the first pair of coordinates in the result will refer to the first point, and the curves, each defined by 3 pairs of coordinates,
  *    will start from the second index of the array.
  * @return {!Array.<number>} The array of the parameters of the curves related to the arc. One curve is defined by 3 pairs of

--- a/src/vector/Element.js
+++ b/src/vector/Element.js
@@ -783,7 +783,7 @@ acgraph.vector.Element.prototype.rotate = function(degrees, opt_cx, opt_cy) {
 
 /**
  Rotates a shape around the given anchor.
- @param {number} degrees Rotation angle in degress.
+ @param {number} degrees Rotation angle in degrees.
  @param {(acgraph.vector.Anchor|string)=} opt_anchor Rotation anchor.
  @return {!acgraph.vector.Element} {@link acgraph.vector.Element} instance for method chaining.
  */

--- a/src/vector/PathBase.js
+++ b/src/vector/PathBase.js
@@ -144,7 +144,7 @@ acgraph.vector.PathBase.forEachSegment_ = function(callback, segments, count, po
  * @param {...number} var_args Segments coordinates.
  * @this {{rect: goog.math.Rect, transform: goog.math.AffineTransform}} Assumed context
  *      is a special object that contains a rectangle which is to be extended and which
- *      will contains the result, as well as trasformation object, if needed.
+ *      will contains the result, as well as transformation object, if needed.
  * @private
  */
 acgraph.vector.PathBase.calcLineBounds_ = function(var_args) {
@@ -177,7 +177,7 @@ acgraph.vector.PathBase.calcLineBounds_ = function(var_args) {
  * @param {number} endY Y coordinate of coordinate.
  * @this {{rect: goog.math.Rect, transform: goog.math.AffineTransform}} Assumed context
  *      is a special object that contains a rectangle which is to be extended and which
- *      will contains the result, as well as trasformation object, if needed.
+ *      will contains the result, as well as transformation object, if needed.
  * @private
  */
 acgraph.vector.PathBase.calcArcBounds_ = function(startX, startY, rx, ry, angle, extent, endX, endY) {
@@ -257,7 +257,7 @@ acgraph.vector.PathBase.calcArcBounds_ = function(startX, startY, rx, ry, angle,
  *      each including 2 control points and an endpoint. Each point is defined by a pair of coordinates – X and Y.
  * @this {{rect: goog.math.Rect, transform: goog.math.AffineTransform}} Assumed context
  *      is a special object that contains a rectangle which is to be extended and which
- *      will contains the result, as well as trasformation object, if needed.
+ *      will contains the result, as well as transformation object, if needed.
  * @private
  */
 acgraph.vector.PathBase.calcCurveBounds_ = function(var_args) {
@@ -275,7 +275,7 @@ acgraph.vector.PathBase.calcCurveBounds_ = function(var_args) {
  * Very rough calculation of bounding rectangle (as IE does in VML) for Bezier curves.
  * Each curve is defined by 3 points (6 coordinates) – 2 control points and an endpoint.
  *
- * Calculation is bazed on fact that any Bezier curve always contained withing trapeziod
+ * Calculation is bazed on fact that any Bezier curve always contained withing trapezoid
  * built on start and end points and two control points. So, we can just add all 4 points
  * into the boundin rectangle.
  *
@@ -283,7 +283,7 @@ acgraph.vector.PathBase.calcCurveBounds_ = function(var_args) {
  *      each including 2 control points and an endpoint. Each point is defined by a pair of coordinates – X and Y.
  * @this {{rect: goog.math.Rect, transform: goog.math.AffineTransform}} Assumed context
  *      is a special object that contains a rectangle which is to be extended and which
- *      will contains the result, as well as trasformation object, if needed.
+ *      will contains the result, as well as transformation object, if needed.
  * @private
  */
 acgraph.vector.PathBase.calcRoughCurveBounds_ = function(var_args) {
@@ -1002,7 +1002,7 @@ acgraph.vector.PathBase.boundsCalculationMap_ = (function() {
 
 
 /**
- * Path lenght.
+ * Path length.
  * @return {number} .
  */
 acgraph.vector.PathBase.prototype.getLength = function() {

--- a/src/vector/Renderer.js
+++ b/src/vector/Renderer.js
@@ -657,7 +657,7 @@ acgraph.vector.Renderer.prototype.setTransformation = goog.abstractMethod;
 
 
 /**
- * Sets transofrmatin to DOM path.
+ * Sets transformation to DOM path.
  * @param {!acgraph.vector.PathBase} element Element.
  */
 acgraph.vector.Renderer.prototype.setPathTransformation = goog.abstractMethod;

--- a/src/vector/Stage.js
+++ b/src/vector/Stage.js
@@ -959,7 +959,7 @@ acgraph.vector.Stage.prototype.getDefs = function() {
 
 
 /**
- TODO: We need to create method to clear SVG because there is no sence to clear defs only.<br/>
+ TODO: We need to create method to clear SVG because there is no sense to clear defs only.<br/>
  Destroy all content (e.g. gradients, some fill and etc.) in defs node.
  @deprecated used only in AnyChartHTML5 v6.
  */
@@ -1097,7 +1097,7 @@ acgraph.vector.Stage.prototype.acquireDomChange = function(changeType) {
 
 /**
  * Tries to reserve no more than one third of all available changes.
- * When rendering is async there is no sence in creating all elements and then hit the limit
+ * When rendering is async there is no sense in creating all elements and then hit the limit
  * of adding - it is better to take into account that adding will require the same number
  * of operations as creation.
  * @return {number} Number of changes allowed.

--- a/src/vector/vml/Defs.js
+++ b/src/vector/vml/Defs.js
@@ -11,7 +11,7 @@ goog.require('acgraph.vector.vml.ShapeType');
  * is a critical task. The class palys the role of an element manager: elements can be
  * assigned to other VML elements (using a reference to their IDs), which will inherit their properties. In VML
  * ShapeType elements are used for that. They are hidden by default, but if a ShapeType element is
- * assigned using a reference to, for example, a Shape element, the latter inherits the ShapeType propeties and applies them to the shape. In a ShapeType
+ * assigned using a reference to, for example, a Shape element, the latter inherits the ShapeType properties and applies them to the shape. In a ShapeType
  * you can also define subnodes, such as fill, stroke, skew, textpath, and so on. A Shape element to which such a ShapeType
  * will be applied will inherit all its properties and will be painted with the given fill and stroke. Let us suppose there are 1000 Shape elements
  * with the same fill and stroke (that require DOM elements). Without a ShapeType, one would have to assign fill and stroke as DOM elements


### PR DESCRIPTION
There are small typos in:
- src/math.js
- src/vector/Element.js
- src/vector/PathBase.js
- src/vector/Renderer.js
- src/vector/Stage.js
- src/vector/vml/Defs.js

Fixes:
- Should read `transformation` rather than `trasformation`.
- Should read `sense` rather than `sence`.
- Should read `trapezoid` rather than `trapeziod`.
- Should read `transformation` rather than `transofrmatin`.
- Should read `properties` rather than `propeties`.
- Should read `length` rather than `lenght`.
- Should read `initial` rather than `intial`.
- Should read `degrees` rather than `degress`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md